### PR TITLE
Remove need to specify $modulePrefix

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -26,11 +26,15 @@ class StdModule
     private $tempVersion;
     private $actions = [];
 
-    public function __construct($code = '')
+    public function __construct($modulePrefix = '', $code = '')
     {
         $class = $this::class;
 
-        $this->modulePrefix = 'MODULE_' . strtoupper($class);
+        if ($modulePrefix) {
+            $this->modulePrefix = $modulePrefix;
+        } else {
+            $this->modulePrefix = 'MODULE_' . strtoupper($class);
+        }
 
         if ($code) {
             $this->code = $code;
@@ -44,6 +48,14 @@ class StdModule
         $this->enabled = $this->getEnabled();
 
         $this->addKey('STATUS');
+    }
+
+    public function init($modulePrefix, $code = '')
+    {
+        self::__construct($modulePrefix, $code);
+
+        /** E_USER_DEPRECATED does not work */
+        trigger_error('Using the init method is deprecated. Use parent::__construct instead.', E_USER_NOTICE);
     }
 
     public function addMessage($message, $messageType = self::MESSAGE_ERROR)

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -28,7 +28,7 @@ class StdModule
 
     public function __construct($code = '')
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         $this->modulePrefix = 'MODULE_' . strtoupper($class);
 

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -26,14 +26,16 @@ class StdModule
     private $tempVersion;
     private $actions = [];
 
-    public function init($modulePrefix, $code = '')
+    public function __construct($code = '')
     {
-        $this->modulePrefix = $modulePrefix;
+        $class = get_class($this);
+
+        $this->modulePrefix = 'MODULE_' . strtoupper($class);
 
         if ($code) {
             $this->code = $code;
         } else {
-            $this->code = get_class($this);
+            $this->code = $class;
         }
 
         $this->title = $this->getTitle();


### PR DESCRIPTION
Since the class name has to be in snake case, I think it would be smart to simplify the module initialisation. 

Before:
```php
class mc_my_first_module extends StdModule
{
    public function __construct()
    {
        $this->init('MODULE_MC_MY_FIRST_MODULE');
    }
}
```


Now:
```php
class mc_my_first_module extends StdModule
{
    public function __construct()
    {
        parent::__construct();
    }
}
```

I'm guessing you want to add some kind of backwards compatibility, so let's hear it!