### PR TITLE
Add module link to update prompt

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -306,10 +306,10 @@ class StdModule
         }
 
         $moduleLink = xtc_href_link(
-            FILENAME_MODULE_EXPORT,
+            pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_BASENAME),
             http_build_query(
                 array(
-                    'set' => 'system',
+                    'set' => $_GET['set'],
                     'module' => $this->code
                 )
             ),

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -306,7 +306,7 @@ class StdModule
         }
 
         $this->addMessage(
-            $this->getConfig('TITLE') .
+            '<a href="' . xtc_href_link(FILENAME_MODULE_EXPORT, http_build_query(array('set' => 'system', 'module' => $this->code)), 'SSL') . '">' . $this->getConfig('TITLE') . '</a>' .
             ' benötigt ein Update ' . $from . ' auf ' .
             static::VERSION . ' - Klicken Sie dafür beim Modul auf Update.'
         );

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -305,10 +305,26 @@ class StdModule
             $from = ' von ' . $this->getVersion();
         }
 
+        $moduleLink = xtc_href_link(
+            FILENAME_MODULE_EXPORT,
+            http_build_query(
+                array(
+                    'set' => 'system',
+                    'module' => $this->code
+                )
+            ),
+            'SSL'
+        );
         $this->addMessage(
-            '<a href="' . xtc_href_link(FILENAME_MODULE_EXPORT, http_build_query(array('set' => 'system', 'module' => $this->code)), 'SSL') . '">' . $this->getConfig('TITLE') . '</a>' .
-            ' benötigt ein Update ' . $from . ' auf ' .
-            static::VERSION . ' - Klicken Sie dafür beim Modul auf Update.'
+            sprintf(
+                /** TRANSLATORS: %1$s: Module name. %2$s: Module current version. %3$s: Module new version. */
+                '%1$s benötigt ein Update von %2$s auf %3$s - Klicken Sie dafür beim Modul auf Update.',
+                '<a href="' . $moduleLink . '">' .
+                    $this->getConfig('TITLE') .
+                '</a>',
+                $from,
+                static::VERSION
+            )
         );
 
         if ($showUpdateButton) {


### PR DESCRIPTION
This PR adds a link to the module name in the update prompt so you can easily select the module and don't have to look for it manually in the list.

![image](https://user-images.githubusercontent.com/45571053/211588912-c1c3d95b-52ee-4b3a-988a-c1ae36d548c9.png)
