### PR TITLE
Force LF breaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text=auto eol=lf


### PR DESCRIPTION
AFAIK PSR-12 requires LF breaks in files. With this git configuration all text files are automatically converted to LF instead of using what is custom on the OS.

As a windows user, which usually tends to use CRLF, this is a blessing and I recommend this.