### PR TITLE
Add version prefix

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -97,7 +97,7 @@ class StdModule
         $version = $this->getVersion();
         $title = $this->getConfig('TITLE');
         if ($version) {
-            return $title . ' (' . $version . ')';
+            return $title . ' (v' . $version . ')';
         }
         return $title;
     }


### PR DESCRIPTION
As mentioned in [Discord](https://discord.com/channels/727190419158597683/1057586830800863232/1057930562905571390), I recommend using adding a `v` prefix to version numbers.

![image](https://user-images.githubusercontent.com/45571053/212692194-d978d113-4b0f-4d3f-91d3-46e4d6cfb9ea.png)
