### PR TITLE
Fix undefined array key "moduleaction"

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -312,7 +312,9 @@ class StdModule
             return false; // do not check for update
         }
 
-        $this->invokeAction();
+        if (isset($_GET['moduleaction'])) {
+            $this->invokeAction();
+        }
 
         if ($_GET['action']) {
             return false; // do not check for update


### PR DESCRIPTION
Currently, if you select a (shipping) module, the `checkForUpdate()` method will cause a warning during `invokeAction()`.

https://github.com/RobinTheHood/modified-std-module/blob/800c5e4d0f3628f5e8436d5f0eec987695075aba/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php#L418

This PR fixes that.