### PR TITLE
Abort update check if user is not an admin

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -305,7 +305,7 @@ class StdModule
     public function checkForUpdate($showUpdateButton = false): bool
     {
         /** Abort if the user is not an admin */
-        if (!isset($_SESSION['customers_status']['customers_status_id']) || '1' === $_SESSION['customers_status']['customers_status_id']) {
+        if (!isset($_SESSION['customers_status']['customers_status_id']) || '0' !== $_SESSION['customers_status']['customers_status_id']) {
             return false;
         }
 

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -304,6 +304,11 @@ class StdModule
      */
     public function checkForUpdate($showUpdateButton = false): bool
     {
+        /** Abort if the user is not an admin */
+        if (!isset($_SESSION['customers_status']['customers_status_id']) || '1' === $_SESSION['customers_status']['customers_status_id']) {
+            return false;
+        }
+
         if (!$this->enabled) {
             return false; // do not check for update
         }


### PR DESCRIPTION
Currently logged-out customers can see if a module update is available. This PR fixes that.

![image](https://user-images.githubusercontent.com/45571053/215743175-b1411fc3-b57a-4a24-aa77-065c5a585e6d.png)
