### PR TITLE
Set getConfig default return to false

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -146,11 +146,12 @@ class StdModule
         return $this->modulePrefix;
     }
 
-    public function getConfig($name, $default = '')
+    public function getConfig($name, $default = false): mixed
     {
         $constantName = $this->getModulePrefix() . '_' . $name;
+        $configurationValue = defined($constantName) ? constant($constantName) : $default;
 
-        return defined($constantName) ? constant($constantName) : $default;
+        return $configurationValue;
     }
 
     public function getVersion()


### PR DESCRIPTION
Currently I have a few configuration values which are empty because modified would otherwise throw an error, if they didn't exist.

```php
define('MODULE_SHIPPING_MC_MY_FIRST_MODULE_ALLOWED_ZONES', '');

$allowedZones = $this->getConfig('ALLOWED_ZONED');

if('' !== $allowedZones) {
    [...]
} else {
    /** Configuration does not exist */
}
```
This would return an empty string which evaluates as falsy. I think a default of `false` would make more sense so you can reliably determine if a configuration exists or not

```php
if(false !== $allowedZones) {
    [...]
} else {
    /** Configuration does not exist */
}
```