### PR TITLE
Refactor non-static methods into static methods

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
@@ -26,7 +26,7 @@ class CaseConverter
         }
 
         $camelString = implode('', $camelParts);
-        $camelString = lcfirst($string);
+        $camelString = lcfirst($camelString);
 
         return $camelString;
     }

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
@@ -2,8 +2,6 @@
 
 namespace RobinTheHood\ModifiedStdModule\Classes;
 
-use RobinTheHood\ModifiedStdModule\Classes\CaseConverter;
-
 class CaseConverter
 {
     /**

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
@@ -16,19 +16,16 @@ class CaseConverter
     public static function screamingToCamel(string $screamingString): string
     {
         $screamingParts = explode('_', $screamingString);
-        $camelParts = [];
-        $camelString = '';
+        $camelParts = array_map(
+            $screamingParts,
+            function (string $camelPart) {
+                $camelPart = strtolower($camelPart);
+                $camelPart = ucfirst($camelPart);
 
-        foreach ($screamingParts as $screamingPart) {
-            $camelPart = $screamingPart;
-            $camelPart = strtolower($camelPart);
-            $camelPart = ucfirst($camelPart);
-
-            $camelParts[] = $camelPart;
-        }
-
+                return $camelPart;
+            }
+        );
         $camelString = implode('', $camelParts);
-        $camelString = lcfirst($camelString);
 
         return $camelString;
     }
@@ -43,15 +40,14 @@ class CaseConverter
     public static function screamingToLisp(string $screamingString): string
     {
         $screamingParts = explode('_', $screamingString);
-        $lispParts = [];
-        $lispString = '';
+        $lispParts = array_map(
+            $screamingParts,
+            function (string $lispPart) {
+                $lispPart = strtolower($lispPart);
 
-        foreach ($screamingParts as $screamingPart) {
-            $lispPart = strtolower($screamingPart);
-
-            $lispParts[] = $lispPart;
-        }
-
+                return $lispPart;
+            }
+        );
         $lispString = implode('-', $lispParts);
 
         return $lispString;

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
@@ -2,6 +2,8 @@
 
 namespace RobinTheHood\ModifiedStdModule\Classes;
 
+use RobinTheHood\ModifiedStdModule\Classes\CaseConverter;
+
 class CaseConverter
 {
     /**

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/CaseConverter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace RobinTheHood\ModifiedStdModule\Classes;
+
+class CaseConverter
+{
+    /**
+     * Convert SCREAMING_SNAKE_CASE to camelCase.
+     *
+     * @param string $screamingString The SCREAMING_SNAKE_CASE to convert.
+     *
+     * @return string
+     */
+    public static function screamingToCamel(string $screamingString): string
+    {
+        $screamingParts = explode('_', $screamingString);
+        $camelParts = [];
+        $camelString = '';
+
+        foreach ($screamingParts as $screamingPart) {
+            $camelPart = $screamingPart;
+            $camelPart = strtolower($camelPart);
+            $camelPart = ucfirst($camelPart);
+
+            $camelParts[] = $camelPart;
+        }
+
+        $camelString = implode('', $camelParts);
+        $camelString = lcfirst($string);
+
+        return $camelString;
+    }
+
+    /**
+     * Convert SCREAMING_SNAKE_CASE to lisp-case.
+     *
+     * @param string $screamingString The SCREAMING_SNAKE_CASE to convert.
+     *
+     * @return string
+     */
+    public static function screamingToLisp(string $screamingString): string
+    {
+        $screamingParts = explode('_', $screamingString);
+        $lispParts = [];
+        $lispString = '';
+
+        foreach ($screamingParts as $screamingPart) {
+            $lispPart = strtolower($screamingPart);
+
+            $lispParts[] = $lispPart;
+        }
+
+        $lispString = implode('-', $lispParts);
+
+        return $lispString;
+    }
+}

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
@@ -6,25 +6,7 @@ class Configuration
 {
     private $prefix;
 
-    public function __construct($prefix)
-    {
-        $this->prefix = $prefix;
-
-        $constants = $this->filterConstants($prefix);
-
-        $this->defineVariablesFromContants($constants, $prefix);
-    }
-
-    public function __get($key)
-    {
-        if (isset($this->$key)) {
-            return $this->$key;
-        }
-
-        throw new \RuntimeException("Unknown configuration variable " . $key);
-    }
-
-    private function filterConstants($prefix)
+    private static function filterConstants($prefix)
     {
         $result = [];
 
@@ -40,22 +22,12 @@ class Configuration
         return $result;
     }
 
-    private function defineVariablesFromContants($constants, $prefix)
-    {
-        foreach ($constants as $key => $value) {
-            $var = $this->removePrefix($key, $prefix);
-            $var = $this->screamingCaseToCamelCase($var);
-
-            $this->$var = $value;
-        }
-    }
-
-    private function removePrefix($string, $prefix)
+    private static function removePrefix($string, $prefix)
     {
         return str_replace($prefix, '', $string);
     }
 
-    public function screamingCaseToCamelCase($string)
+    public static function screamingCaseToCamelCase($string)
     {
         $parts = explode('_', $string);
 
@@ -73,7 +45,7 @@ class Configuration
         return $string;
     }
 
-    public function screamingCaseToLispCase(string $string)
+    public static function screamingCaseToLispCase(string $string)
     {
         $parts = explode('_', $string);
 
@@ -88,5 +60,33 @@ class Configuration
         $string = implode('-', $parts);
 
         return $string;
+    }
+
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+
+        $constants = self::filterConstants($prefix);
+
+        $this->defineVariablesFromContants($constants, $prefix);
+    }
+
+    public function __get($key)
+    {
+        if (isset($this->$key)) {
+            return $this->$key;
+        }
+
+        throw new \RuntimeException("Unknown configuration variable " . $key);
+    }
+
+    private function defineVariablesFromContants($constants, $prefix)
+    {
+        foreach ($constants as $key => $value) {
+            $var = self::removePrefix($key, $prefix);
+            $var = self::screamingCaseToCamelCase($var);
+
+            $this->$var = $value;
+        }
     }
 }

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
@@ -6,7 +6,25 @@ class Configuration
 {
     private $prefix;
 
-    private static function filterConstants($prefix)
+    public function __construct($prefix)
+    {
+        $this->prefix = $prefix;
+
+        $constants = $this->filterConstants($prefix);
+
+        $this->defineVariablesFromContants($constants, $prefix);
+    }
+
+    public function __get($key)
+    {
+        if (isset($this->$key)) {
+            return $this->$key;
+        }
+
+        throw new \RuntimeException("Unknown configuration variable " . $key);
+    }
+
+    private function filterConstants($prefix)
     {
         $result = [];
 
@@ -22,12 +40,22 @@ class Configuration
         return $result;
     }
 
-    private static function removePrefix($string, $prefix)
+    private function defineVariablesFromContants($constants, $prefix)
+    {
+        foreach ($constants as $key => $value) {
+            $var = $this->removePrefix($key, $prefix);
+            $var = $this->screamingCaseToCamelCase($var);
+
+            $this->$var = $value;
+        }
+    }
+
+    private function removePrefix($string, $prefix)
     {
         return str_replace($prefix, '', $string);
     }
 
-    public static function screamingCaseToCamelCase($string)
+    public function screamingCaseToCamelCase($string)
     {
         $parts = explode('_', $string);
 
@@ -45,7 +73,7 @@ class Configuration
         return $string;
     }
 
-    public static function screamingCaseToLispCase(string $string)
+    public function screamingCaseToLispCase(string $string)
     {
         $parts = explode('_', $string);
 
@@ -60,33 +88,5 @@ class Configuration
         $string = implode('-', $parts);
 
         return $string;
-    }
-
-    public function __construct($prefix)
-    {
-        $this->prefix = $prefix;
-
-        $constants = self::filterConstants($prefix);
-
-        $this->defineVariablesFromContants($constants, $prefix);
-    }
-
-    public function __get($key)
-    {
-        if (isset($this->$key)) {
-            return $this->$key;
-        }
-
-        throw new \RuntimeException("Unknown configuration variable " . $key);
-    }
-
-    private function defineVariablesFromContants($constants, $prefix)
-    {
-        foreach ($constants as $key => $value) {
-            $var = self::removePrefix($key, $prefix);
-            $var = self::screamingCaseToCamelCase($var);
-
-            $this->$var = $value;
-        }
     }
 }

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace RobinTheHood\ModifiedStdModule\Classes;
 
+use RobinTheHood\ModifiedStdModule\Classes\CaseConverter;
+
 class Configuration
 {
     private $prefix;

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/Configuration.php
@@ -44,7 +44,7 @@ class Configuration
     {
         foreach ($constants as $key => $value) {
             $var = $this->removePrefix($key, $prefix);
-            $var = $this->screamingCaseToCamelCase($var);
+            $var = CaseConverter::screamingToCamel($var);
 
             $this->$var = $value;
         }
@@ -57,36 +57,31 @@ class Configuration
 
     public function screamingCaseToCamelCase($string)
     {
-        $parts = explode('_', $string);
+        trigger_error(
+            sprintf(
+                /** TRANSLATORS: %1$s: Old method name. %2$s: New method name.*/
+                'Using the %1$s method is deprecated. Use %2$s instead.',
+                __METHOD__,
+                'CaseConverter::screamingToCamel'
+            ),
+            E_USER_DEPRECATED
+        );
 
-        foreach ($parts as &$part) {
-            if (!$part) {
-                continue;
-            }
-
-            $part = strtolower($part);
-            $part = ucfirst($part);
-        }
-
-        $string = implode('', $parts);
-        $string = lcfirst($string);
-        return $string;
+        return CaseConverter::screamingToCamel($string);
     }
 
     public function screamingCaseToLispCase(string $string)
     {
-        $parts = explode('_', $string);
+        trigger_error(
+            sprintf(
+                /** TRANSLATORS: %1$s: Old method name. %2$s: New method name.*/
+                'Using the %1$s method is deprecated. Use %2$s instead.',
+                __METHOD__,
+                'CaseConverter::screamingToLisp'
+            ),
+            E_USER_DEPRECATED
+        );
 
-        foreach ($parts as &$part) {
-            if (!$part) {
-                continue;
-            }
-
-            $part = strtolower($part);
-        }
-
-        $string = implode('-', $parts);
-
-        return $string;
+        return CaseConverter::screamingToLisp($string);
     }
 }


### PR DESCRIPTION
I am using a lot of static methods and noticed there is no real reason that these methods are non-static. It would simply things a lot (for me), and perhaps in general too.