### PR TITLE
fix getConfig mixed type hint

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -146,7 +146,7 @@ class StdModule
         return $this->modulePrefix;
     }
 
-    public function getConfig($name, $default = false): mixed
+    public function getConfig($name, $default = false)
     {
         $constantName = $this->getModulePrefix() . '_' . $name;
         $configurationValue = defined($constantName) ? constant($constantName) : $default;


### PR DESCRIPTION
So I just ran into this strange error:
```
Return value of RobinTheHood\ModifiedStdModule\Classes\StdModule::getConfig() must be an instance of RobinTheHood\ModifiedStdModule\Classes\mixed, string returned in File: [...]\vendor-no-composer\robinthehood\ModifiedStdModule\Classes\StdModule.php on Line: 154	{}	{}
```

I did some research and apparently
> `mixed` is not a valid type for hinting in PHP.
>
> https://stackoverflow.com/questions/49251537/php-typeerror-parameter-must-be-an-instance-of-lib-util-mixed-string-given/49251713#49251713

I've been using it for years and never had this error but here we are. 