### PR TITLE
fix: constant already defined

### DIFF
--- a/tests/StdModuleTest.php
+++ b/tests/StdModuleTest.php
@@ -24,7 +24,7 @@ final class StdModuleTest extends TestCase
         'MODULE_ORDER_TOTAL_MC_MY_FIRST_INACTIVE_MODULE',
     ];
 
-    protected function setUp(): void
+    public static function setUpBeforeClass(): void
     {
         foreach (self::$moduleNamesActive as $moduleName) {
             define($moduleName . '_STATUS', 'true');


### PR DESCRIPTION
TL;DR: `setUp` is run for each test and is causing a PHP Warning. This PR fixes that.

> The setUp() [...] template methods are run once for each test method (and on fresh instances) of the test case class. 
> In addition, the setUpBeforeClass() [...] template methods are called before the first test of the test case class is run [...]
>
> https://phpunit.de/manual/6.5/en/fixtures.html