### PR TITLE
Feature request: remove all module settings

### DIFF
--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -281,9 +281,11 @@ class StdModule
             )
         );
 
-        $success = false !== $remove_configuration;
+        if (false === $remove_configuration) {
+            return false;
+        }
 
-        return $success;
+        return true;
     }
 
     public function removeConfiguration(string $key): bool

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -271,7 +271,7 @@ class StdModule
 
     public function removeConfigurationAll(): bool
     {
-        $module_name          = $this->getModulePrefix();
+        $module_name = $this->getModulePrefix();
         $remove_configuration = xtc_db_query(
             sprintf(
                 /** TRANSLATORS: %1$s: Database table "configuration". %2$s: Value for "configuration_key". */

--- a/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/new_files/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -269,6 +269,23 @@ class StdModule
         xtc_db_query("INSERT INTO `" . TABLE_CONFIGURATION . "` (`configuration_key`, `configuration_value`, `configuration_group_id`, `sort_order`, `set_function`, `use_function`, `date_added`) VALUES ('$key', '$value', '$groupId', '$sortOrder', '$setFunction', '$useFunction', NOW())");
     }
 
+    public function removeConfigurationAll(): bool
+    {
+        $module_name          = $this->getModulePrefix();
+        $remove_configuration = xtc_db_query(
+            sprintf(
+                /** TRANSLATORS: %1$s: Database table "configuration". %2$s: Value for "configuration_key". */
+                'DELETE FROM `%1$s` WHERE `configuration_key` LIKE "%2$s_%"',
+                TABLE_CONFIGURATION,
+                $module_name
+            )
+        );
+
+        $success = false !== $remove_configuration;
+
+        return $success;
+    }
+
     public function removeConfiguration(string $key): bool
     {
         $key              = $this->getModulePrefix() . '_' . $key;


### PR DESCRIPTION
The advantage here is that the developer can't forget to remove settings he has added, making an uninstall clean without leaving any orphans behind (unless he specifically wants to).

```php
public function remove()
{
    parent::remove();

    $this->removeConfigurationAll();
}
```