### PR TITLE
feat: add application callback autoloader

### DIFF
--- a/src/includes/extra/application_top_callback/application_top_callback_begin/rth_modified_std_module.php
+++ b/src/includes/extra/application_top_callback/application_top_callback_begin/rth_modified_std_module.php
@@ -1,0 +1,23 @@
+<?php
+
+use RobinTheHood\ModifiedStdModule\Classes\StdModule;
+
+// Normaly the autload.php is loaded by the composer/autoload, but we do not know
+// the file order in /includes/extra/functions/. So if this file is loaded first,
+// the composer/autoload dose not loaded the autoload.php already and we have to
+// to load autoload.php by ourself.
+require_once DIR_FS_DOCUMENT_ROOT . '/vendor-no-composer/autoload.php';
+
+if (!function_exists('rth_is_module_enabled')) {
+    function rth_is_module_enabled(string $moduleName): bool
+    {
+        return StdModule::isEnabled($moduleName);
+    }
+}
+
+if (!function_exists('rth_is_module_disabled')) {
+    function rth_is_module_disabled(string $moduleName): bool
+    {
+        return StdModule::isDisabled($moduleName);
+    }
+}


### PR DESCRIPTION
I have just encountered a module which loads:
```php
require 'includes/application_top_callback.php';
```

Which then loads:
```php
// include shopping cart class
require_once (DIR_WS_CLASSES.'shopping_cart.php');
```

Which causes modules using this library to error:
```log
Class "RobinTheHood\ModifiedStdModule\Classes\StdModule" not found in File: [...]\includes\modules\shopping_cart\grandeljay_always_available_shopping_cart.php on Line: 16{}{}
```

This PR fixes that error for all `shopping_cart` modules extending `StdModule`.