### PR TITLE
fix: multiple `invokeUpdate` calls

### DIFF
--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -392,7 +392,7 @@ class StdModule
             return $version;
         }
 
-        $versionConstant = \sprintf('%s_VERSION', $this->modulePrefix);
+        $versionConstant = $this->modulePrefix . '_VERSION';
         $versionQuery = \xtc_db_query(
             \sprintf(
                 'SELECT `configuration_value`

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -387,7 +387,7 @@ class StdModule
      *
      * @return mixed The configuration value for the specified key, or the
      *               default value if the key is not defined. Once the PHP
-     *               requirements go up to >= 8.0, we can return `string|false`
+     *               requirements go up to >= 8.2, we can return `string|false`
      *               instead.
      */
     protected function getConfigFromDb(string $name, $default = false): mixed

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -390,7 +390,7 @@ class StdModule
      *               requirements go up to >= 8.2, we can return `string|false`
      *               instead.
      */
-    protected function getConfigFromDb(string $name, $default = false): mixed
+    protected function getConfigFromDb(string $name, $default = false): string
     {
         $configConstant = $this->modulePrefix . '_' . $name;
         $configQuery = \xtc_db_query(

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -375,6 +375,43 @@ class StdModule
     }
 
     /**
+     * Gets the configuration value for a given configuration key directly from
+     * the database. This is usually not necesary, unless you have a specific
+     * reason, please use `getConfig` instead.
+     *
+     * @param string $name    The key of the configuration.
+     * @param mixed  $default The default value to return if the configuration
+     *                        key is not defined.
+     *
+     * @see getConfig() Gets the configuration.
+     *
+     * @return mixed The configuration value for the specified key, or the
+     *               default value if the key is not defined. Once the PHP
+     *               requirements go up to >= 8.0, we can return `string|false`
+     *               instead.
+     */
+    protected function getConfigFromDb(string $name, $default = false): mixed
+    {
+        $configConstant = $this->modulePrefix . '_' . $name;
+        $configQuery = \xtc_db_query(
+            \sprintf(
+                'SELECT `configuration_value`
+                   FROM `%s`
+                  WHERE `configuration_key` = "%s"',
+                \TABLE_CONFIGURATION,
+                $configConstant
+            )
+        );
+        $configData = $configQuery instanceof \mysqli_result
+                    ? \xtc_db_fetch_array($configQuery)
+                    : null;
+        $configValue = $configData['configuration_value']
+                     ?? $default;
+
+        return $configValue;
+    }
+
+    /**
      * Gets the version of the module.
      *
      * If the temporary version (`tempVersion`) is not set, it retrieves the version
@@ -392,18 +429,7 @@ class StdModule
             return $version;
         }
 
-        $versionConstant = $this->modulePrefix . '_VERSION';
-        $versionQuery = \xtc_db_query(
-            \sprintf(
-                'SELECT `configuration_value`
-                   FROM `%s`
-                  WHERE `configuration_key` = "%s"',
-                \TABLE_CONFIGURATION,
-                $versionConstant
-            )
-        );
-        $versionData = \xtc_db_fetch_array($versionQuery);
-        $version = $versionData['configuration_value'] ?? '';
+        $version = $this->getConfigFromDb('VERSION');
 
         return $version;
     }

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -376,7 +376,7 @@ class StdModule
 
     /**
      * Gets the configuration value for a given configuration key directly from
-     * the database. This is usually not necesary, unless you have a specific
+     * the database. This is usually not necessary, unless you have a specific
      * reason, please use `getConfig` instead.
      *
      * @param string $name    The key of the configuration.

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -388,20 +388,22 @@ class StdModule
     {
         $version = $this->tempVersion ?? '';
 
-        if ('' === $version) {
-            $versionConstant = \sprintf('%s_VERSION', $this->modulePrefix);
-            $versionQuery = \xtc_db_query(
-                \sprintf(
-                    'SELECT `configuration_value`
-                       FROM `%s`
-                      WHERE `configuration_key` = "%s"',
-                    \TABLE_CONFIGURATION,
-                    $versionConstant
-                )
-            );
-            $versionData = \xtc_db_fetch_array($versionQuery);
-            $version = $versionData['configuration_value'] ?? '';
+        if ('' !== $version) {
+            return $version;
         }
+
+        $versionConstant = \sprintf('%s_VERSION', $this->modulePrefix);
+        $versionQuery = \xtc_db_query(
+            \sprintf(
+                'SELECT `configuration_value`
+                   FROM `%s`
+                  WHERE `configuration_key` = "%s"',
+                \TABLE_CONFIGURATION,
+                $versionConstant
+            )
+        );
+        $versionData = \xtc_db_fetch_array($versionQuery);
+        $version = $versionData['configuration_value'] ?? '';
 
         return $version;
     }

--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -386,11 +386,24 @@ class StdModule
      */
     protected function getVersion(): string
     {
-        $tempVersion = $this->tempVersion ?? '';
-        if (!$tempVersion) {
-            $this->tempVersion = $this->getConfig('VERSION');
+        $version = $this->tempVersion ?? '';
+
+        if ('' === $version) {
+            $versionConstant = \sprintf('%s_VERSION', $this->modulePrefix);
+            $versionQuery = \xtc_db_query(
+                \sprintf(
+                    'SELECT `configuration_value`
+                       FROM `%s`
+                      WHERE `configuration_key` = "%s"',
+                    \TABLE_CONFIGURATION,
+                    $versionConstant
+                )
+            );
+            $versionData = \xtc_db_fetch_array($versionQuery);
+            $version = $versionData['configuration_value'] ?? '';
         }
-        return $this->tempVersion;
+
+        return $version;
     }
 
     /**


### PR DESCRIPTION
The `invokeUpdate` function is called up to three times in modified, causing errors in my database migration. If I am using this library incorrectly, please let me know.

## My code
```php
public function __construct()
{
    parent::__construct(Constants::MODULE_SHIPPING_NAME);

    $this->checkForUpdate(true);
    [...]
}
```
[...]
```php
protected function updateSteps(): int
{
    $version_before_update = $this->getVersion();
    $version_after_update  = self::VERSION;

    if (version_compare($version_before_update, '0.9.0', '<=')) {
        $installer = new ModuleInstaller($this);
        $installer->installBulkPriceChangePreview(); /** Migration is happening here */
    }

    if (version_compare($version_before_update, $version_after_update, '<')) {
        $this->setVersion($version_after_update);

        return self::UPDATE_SUCCESS;
    }

    return self::UPDATE_NOTHING;
}
```

## The problem
modified is calling my module's constructor **up to three times**, causing `invokeUpdate` to also run up to three times:
https://github.com/RobinTheHood/modified-std-module/blob/079e086ba7e24a456a4af310d332140e0de2728a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php#L280-L300

In modified `v2.0.7.2` the references can be found here:

1. `/admin/modules.php:294` function `check_update_needed`
2. `/admin/modules.php:377`
3. `/admin/modules.php:237` function `output_modules`

## The fix

In an attempt to work around this, this PR unsets `$_GET['moduleaction']`, preventing the `invokeAction` to run up to three times.