### PR TITLE
fix: `sprintf` unknown format specifier

### DIFF
--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -592,7 +592,7 @@ class StdModule
         $remove_configuration = xtc_db_query(
             sprintf(
                 /** TRANSLATORS: %1$s: Database table "configuration". %2$s: Value for "configuration_key". */
-                'DELETE FROM `%1$s` WHERE `configuration_key` LIKE "%2$s_%"',
+                'DELETE FROM `%1$s` WHERE `configuration_key` LIKE "%2$s_%%"',
                 TABLE_CONFIGURATION,
                 $module_name
             )


### PR DESCRIPTION
The `sprintf` function uses `%` characters rather than a backslash `\` to escape characters. To avoid the missing trailing `%` in the SQL query and the subsequent 

> Uncaught ValueError: Unknown format specifier """

error, it is being properly escaped in this PR, allowing the use of the `removeConfigurationAll` method.

https://www.php.net/manual/en/function.sprintf.php#88218