### PR TITLE
fix: duplicate _von_

### DIFF
--- a/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
+++ b/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php
@@ -697,7 +697,7 @@ class StdModule
         }
 
         if ($this->getVersion()) {
-            $from = ' von ' . $this->getVersion();
+            $from = $this->getVersion();
         }
 
         // TODO: extract to own private method


### PR DESCRIPTION
<img width="553" height="39" alt="image" src="https://github.com/user-attachments/assets/f465c33f-79f2-4724-b800-b3e9f488d5f5" />

The `$from` variable does not need to contain the _von_ text:
https://github.com/RobinTheHood/modified-std-module/blob/30d91c1727fa7d38a9680484f931206048affb27/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php#L699-L701

It's already written here:
https://github.com/RobinTheHood/modified-std-module/blob/30d91c1727fa7d38a9680484f931206048affb27/src/vendor-no-composer/robinthehood/ModifiedStdModule/Classes/StdModule.php#L721-L729

This PR fixes that.